### PR TITLE
fix: remove preact dependencies

### DIFF
--- a/lib/Slider.js
+++ b/lib/Slider.js
@@ -1,3 +1,5 @@
+'use strict';
+
 Object.defineProperty(exports, "__esModule", {
   value: true
 });

--- a/lib/algorithms/geometric.js
+++ b/lib/algorithms/geometric.js
@@ -1,3 +1,5 @@
+"use strict";
+
 Object.defineProperty(exports, "__esModule", {
   value: true
 });

--- a/lib/algorithms/linear.js
+++ b/lib/algorithms/linear.js
@@ -1,3 +1,5 @@
+"use strict";
+
 Object.defineProperty(exports, "__esModule", {
   value: true
 });

--- a/lib/algorithms/log10.js
+++ b/lib/algorithms/log10.js
@@ -1,3 +1,5 @@
+"use strict";
+
 Object.defineProperty(exports, "__esModule", {
   value: true
 });

--- a/lib/constants/SliderConstants.js
+++ b/lib/constants/SliderConstants.js
@@ -1,3 +1,5 @@
+"use strict";
+
 Object.defineProperty(exports, "__esModule", {
   value: true
 });

--- a/package.json
+++ b/package.json
@@ -50,6 +50,8 @@
     "jsdom": "^9.12.0",
     "mocha": "^3.5.0",
     "nyc": "^11.1.0",
+    "preact": "^8.2.5",
+    "preact-compat": "^3.17.0",
     "raw-loader": "^0.5.1",
     "react": "^15.6.1",
     "react-addons-test-utils": "^15.6.0",
@@ -61,8 +63,6 @@
   },
   "dependencies": {
     "object.assign": "^4.0.4",
-    "preact": "^8.2.5",
-    "preact-compat": "^3.17.0",
     "prop-types": "^15.5.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -64,5 +64,9 @@
   "dependencies": {
     "object.assign": "^4.0.4",
     "prop-types": "^15.5.10"
+  },
+  "peerDependencies": {
+    "preact": ">= 8.5.0",
+    "preact-compat": ">= 3.17.0"
   }
 }


### PR DESCRIPTION
Right now the package has a hard dependencies on `preact` & `preact-compat`. It can leads to issue (basically duplicate) when the package that requires it also have this dependencies too. This is what happen right now with the latest version of InstantSearch 2.10.4.

![_private_var_folders_t2_chcdrx4d37n2m_yv6k6lyvrw0000gp_t_118931-24282-1r5ykm 65xq html](https://user-images.githubusercontent.com/6513513/47811227-7ce73380-dd02-11e8-9a2c-05b9b6c41e0a.png)
